### PR TITLE
Updating gem dependency to activesupport

### DIFF
--- a/mypage_tools.gemspec
+++ b/mypage_tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "capybara", "~> 2.2.1"
   spec.add_runtime_dependency "poltergeist", "~> 1.5.0"
   spec.add_runtime_dependency "icalendar", "~> 1.5.0"
-  spec.add_runtime_dependency "active_support", "~> 3.0.0"
+  spec.add_runtime_dependency "activesupport", "~> 3.0.0"
   spec.add_runtime_dependency "i18n"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
active_support gem has been removed in favor of activesupport. 
Updated .gemspec

See https://rubygems.org/gems/active_support
